### PR TITLE
multi: Implement `POST /task` endpoint and refactor jwt implementation

### DIFF
--- a/db/mongodb/types.go
+++ b/db/mongodb/types.go
@@ -13,7 +13,7 @@ type dbUser struct {
 }
 
 type dbTask struct {
-	ID      primitive.ObjectID `bson:"_id"`
-	OwnerID string             `bson:"ownerID"`
-	db.TaskInfo
+	ID          primitive.ObjectID `bson:"_id"`
+	OwnerID     string             `bson:"ownerID"`
+	db.TaskInfo `bson:"inline"`
 }

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 )
 
 require (
-	github.com/cristalhq/jwt v1.2.0
+	github.com/cristalhq/jwt/v4 v4.0.2
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/montanaflynn/stats v0.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/cristalhq/jwt v1.2.0 h1:fHmMkFJvEbS4o04aQP8BmtJg7fqkYvd7r8er3sUdS4Q=
-github.com/cristalhq/jwt v1.2.0/go.mod h1:QQFazsDzoqeucUEEV0h16uPTZXBAi2SVA8cQ9JEDuFw=
+github.com/cristalhq/jwt/v4 v4.0.2 h1:g/AD3h0VicDamtlM70GWGElp8kssQEv+5wYd7L9WOhU=
+github.com/cristalhq/jwt/v4 v4.0.2/go.mod h1:HnYraSNKDRag1DZP92rYHyrjyQHnVEHPNqesmzs+miQ=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-chi/chi/v5 v5.1.0 h1:acVI1TYaD+hhedDJ3r54HyA6sExp3HfXq7QWEEY/xMw=

--- a/webserver/middleware.go
+++ b/webserver/middleware.go
@@ -1,0 +1,40 @@
+package webserver
+
+import (
+	"context"
+	"net/http"
+)
+
+const jwtHeader = "Megtask-Authentication-Token"
+const userIDCtxKey = "userID"
+
+// authMiddleware ensures the the correct and valid auth token is provided in
+// this request.
+func (s *WebServer) authMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		authToken := req.Header.Get(jwtHeader)
+		if authToken == "" {
+			s.writeJSONResponse(res, http.StatusUnauthorized, "not authorized")
+			return
+		}
+
+		userID, validToken := s.jwtManager.IsValidToken(authToken)
+		if !validToken {
+			s.writeJSONResponse(res, http.StatusUnauthorized, "not authorized")
+			return
+		}
+
+		// Set userID for use in subsequent handlers.
+		req = req.WithContext(context.WithValue(req.Context(), userIDCtxKey, userID))
+		next.ServeHTTP(res, req)
+	})
+}
+
+// reqUserID retrieves the userID from an authenticated request.
+func (s *WebServer) reqUserID(req *http.Request) string {
+	userIDVal := req.Context().Value(userIDCtxKey)
+	if userIDVal != nil {
+		return userIDVal.(string)
+	}
+	return ""
+}

--- a/webserver/server.go
+++ b/webserver/server.go
@@ -103,6 +103,13 @@ func (s *WebServer) registerRoutes() {
 
 	s.mux.Post("/create-account", s.handleCreateAccount)
 	s.mux.Post("/login", s.handleLogin)
+
+	// Endpoints the require authentication.
+	s.mux.Group(func(authedMux chi.Router) {
+		authedMux.Use(s.authMiddleware)
+
+		authedMux.Post("/task", s.handleCreateTask)
+	})
 }
 
 // handleHome handles the "GET /" endpoint and returns a server message.

--- a/webserver/tasks.go
+++ b/webserver/tasks.go
@@ -1,0 +1,31 @@
+package webserver
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// handleCreateTask handles the "POST /task" endpoint and creates a new task
+// entry for a user.
+func (s *WebServer) handleCreateTask(res http.ResponseWriter, req *http.Request) {
+	form := new(createTaskRequest)
+	if !s.readPostBody(res, req, &form) {
+		return
+	}
+
+	if form.TaskDetail == "" {
+		s.writeBadRequest(res, "missing task detail")
+		return
+	}
+
+	userID := s.reqUserID(req)
+	userTasks, err := s.taskDB.CreateTask(userID, form.TaskDetail)
+	if err != nil {
+		s.writeServerError(res, fmt.Errorf("taskDB.CreateTask error: %w", err))
+		return
+	}
+
+	s.writeSuccess(res, map[string]any{
+		"tasks": userTasks,
+	})
+}

--- a/webserver/types.go
+++ b/webserver/types.go
@@ -31,3 +31,8 @@ func (caq *usernameAndPassword) Validate() error {
 
 	return nil
 }
+
+// createTaskRequest is information required to create new task.
+type createTaskRequest struct {
+	TaskDetail string `json:"taskDetail"`
+}

--- a/webserver/utils.go
+++ b/webserver/utils.go
@@ -17,37 +17,30 @@ func (s *WebServer) readPostBody(res http.ResponseWriter, req *http.Request, bod
 
 // writeSuccess writes a success response.
 func (s *WebServer) writeSuccess(res http.ResponseWriter, respBody any) {
-	res.WriteHeader(http.StatusOK)
-	responseBytes, err := json.Marshal(respBody)
-	if err != nil {
-		s.log.Error("json.Marshal failed to send response: ", "error", err)
-	}
-	res.Write(responseBytes)
+	s.writeJSONResponse(res, http.StatusOK, respBody)
 }
 
 // writeBadRequest writes an http.StatusBadRequest to the response header and an
 // errorMessage.
 func (s *WebServer) writeBadRequest(res http.ResponseWriter, errorMessage string) {
-	res.WriteHeader(http.StatusBadRequest)
-	responseBytes, err := json.Marshal(map[string]string{
+	s.writeJSONResponse(res, http.StatusBadRequest, map[string]string{
 		"errorMessage": errorMessage,
 	})
-	if err != nil {
-		s.log.Error("json.Marshal failed to send bad request: ", "error", err)
-	}
-	res.Write(responseBytes)
 }
 
 // writeServerError writes a server error and logs the provided error.
 func (s *WebServer) writeServerError(res http.ResponseWriter, serverErr error) {
 	s.log.Error("Server error: ", "err", serverErr)
-
-	res.WriteHeader(http.StatusInternalServerError)
-	responseBytes, err := json.Marshal(map[string]string{
-		"errorMessage": "Something unexpected happened. Sorry, try again.",
+	s.writeJSONResponse(res, http.StatusInternalServerError, map[string]string{
+		"errorMessage": "Something unexpected happened, please try again later.",
 	})
+}
+
+func (s *WebServer) writeJSONResponse(res http.ResponseWriter, code int, resp any) {
+	res.WriteHeader(code)
+	responseBytes, err := json.Marshal(resp)
 	if err != nil {
-		s.log.Error("json.Marshal failed to send server error: ", "error", err)
+		s.log.Error("json.Marshal failed: ", "error", err)
 	}
 	res.Write(responseBytes)
 }


### PR DESCRIPTION
This PR implements the `POST /task` endpoint and refactored the jwt implementation.