### PR TITLE
multi: Implement `PATCH /task` endpoint and required `TaskDatabase` method

### DIFF
--- a/db/mongodb/mongodb.go
+++ b/db/mongodb/mongodb.go
@@ -20,10 +20,11 @@ const (
 	taskCollection  = "tasks"
 
 	// Keys
-	dbIDKey      = "_id"
-	usernameKey  = "username"
-	ownerIDKey   = "ownerID"
-	completedKey = "completed"
+	dbIDKey       = "_id"
+	usernameKey   = "username"
+	ownerIDKey    = "ownerID"
+	completedKey  = "completed"
+	taskDetailKey = "detail"
 )
 
 // Check that *MongoDB satisfies webserver.TaskDatabase.

--- a/webserver/db.go
+++ b/webserver/db.go
@@ -22,7 +22,7 @@ type TaskDatabase interface {
 	TasksWithStatus(userID string, completed bool) ([]*db.Task, error)
 	// UpdateTask updates an existing task for the provided userID. If no task
 	// match the provided taskID, an ErrorInvalidRequest is returned.
-	UpdateTask(userID, taskID string, newTaskDetail string) ([]*db.Task, error)
+	UpdateTask(userID, taskID string, newTaskDetail string, markAsComplete *bool) ([]*db.Task, error)
 	// DeleteTask removes an existing task from the record of the user that
 	// match the provided userID. If no task match the provided taskID, an
 	// ErrorInvalidRequest is returned.

--- a/webserver/server.go
+++ b/webserver/server.go
@@ -110,6 +110,7 @@ func (s *WebServer) registerRoutes() {
 
 		authedMux.Post("/task", s.handleCreateTask)
 		authedMux.Get("/tasks", s.handleRetrieveTasks)
+		authedMux.Patch("/task", s.handleUpdateTask)
 	})
 }
 

--- a/webserver/types.go
+++ b/webserver/types.go
@@ -36,3 +36,11 @@ func (caq *usernameAndPassword) Validate() error {
 type createTaskRequest struct {
 	TaskDetail string `json:"taskDetail"`
 }
+
+// updateTaskRequest is information that may be provided to update a task. Both cannot
+// be empty.
+type updateTaskRequest struct {
+	TaskID          string `json:"taskID"`
+	TaskDetail      string `json:"taskDetail"` // optional
+	MarkAsCompleted bool   `json:"markAsCompleted"`
+}


### PR DESCRIPTION
This PR implements the `PATCH /task` endpoint and the `TaskDatabase` method which adds task update capabilities to Megtask.