### PR TITLE
multi: Implement `DELETE /task/{taskID}` endpoint and the required TaskDatabase method

### DIFF
--- a/webserver/server.go
+++ b/webserver/server.go
@@ -111,6 +111,7 @@ func (s *WebServer) registerRoutes() {
 		authedMux.Post("/task", s.handleCreateTask)
 		authedMux.Get("/tasks", s.handleRetrieveTasks)
 		authedMux.Patch("/task", s.handleUpdateTask)
+		authedMux.Delete("/task/{taskID}", s.handleDeleteTask)
 	})
 }
 

--- a/webserver/tasks.go
+++ b/webserver/tasks.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/ukane-philemon/megtask/db"
 )
 
@@ -105,6 +106,26 @@ func (s *WebServer) handleUpdateTask(res http.ResponseWriter, req *http.Request)
 			s.writeBadRequest(res, err.Error())
 		} else {
 			s.writeServerError(res, fmt.Errorf("taskDB.UpdateTask: %w", err))
+		}
+		return
+	}
+
+	s.writeSuccess(res, map[string]any{
+		"tasks": userTasks,
+	})
+}
+
+// handleDeleteTask handles the "DELETE /task/{taskID}" endpoint and removes an
+// existing task from a user's record.
+func (s *WebServer) handleDeleteTask(res http.ResponseWriter, req *http.Request) {
+	taskID := chi.URLParam(req, "taskID")
+	userID := s.reqUserID(req)
+	userTasks, err := s.taskDB.DeleteTask(userID, taskID)
+	if err != nil {
+		if errors.Is(err, db.ErrorInvalidRequest) {
+			s.writeBadRequest(res, err.Error())
+		} else {
+			s.writeServerError(res, fmt.Errorf("taskDB.DeleteTask: %w", err))
 		}
 		return
 	}


### PR DESCRIPTION
This PR implements the `DELETE /task/{taskID}` endpoint and the required TaskDatabase method. 